### PR TITLE
Refactored BottleneckLowestPoint calculation 

### DIFF
--- a/Assets/Unity Simple Liquid/Scripts/SplitController.cs
+++ b/Assets/Unity Simple Liquid/Scripts/SplitController.cs
@@ -84,43 +84,25 @@ namespace UnitySimpleLiquid
             return pos;
         }
 
-        private Vector3 GenerateBottleneckLowesPoint()
-        {
-            if (!liquidContainer)
-                return Vector3.zero;
+		private Vector3 GenerateBottleneckLowesPoint()
+		{
+			if (!liquidContainer)
+				return Vector3.zero;
 
-            // TODO: This code is not optimal and can be done much better
-            // Righ now it caluclates minimal point of the circle (in 3d) by brute force
-            var containerOrientation = liquidContainer.transform.rotation;
+			// Calculate the direction vector of the bottlenecks slope
 
-            // Points on bottleneck radius (local space)
-            var angleStep = 0.1f;
-            var localPoints = new List<Vector3>();
-            for (float a = 0; a < Mathf.PI * 2f; a += angleStep)
-            {
-                var x = BottleneckRadiusWorld * Mathf.Cos(a);
-                var z = BottleneckRadiusWorld * Mathf.Sin(a);
+			Vector3 bottleneckSlope = GetSlopeDirection(Vector3.up, bottleneckPlane.normal);
 
-                localPoints.Add(new Vector3(x, 0, z));
-            }
+			// Find a position along the slope the side of the bottleneck radius
+			Vector3 min = BottleneckPos + bottleneckSlope * BottleneckRadiusWorld;
 
-            // Transfer points from local to global
-            var worldPoints = new List<Vector3>();
-            foreach (var locPoint in localPoints)
-            {
-                var worldPoint = BottleneckPos + containerOrientation * locPoint;
-                worldPoints.Add(worldPoint);
-            }
+			return min;
 
-            // Find the lowest one
-            var min = worldPoints.OrderBy((pt) => pt.y).First();
-            return min;
+		}
+		#endregion
 
-        }
-        #endregion
-
-        #region Gizmos
-        private void OnDrawGizmosSelected()
+		#region Gizmos
+		private void OnDrawGizmosSelected()
         {
             // Draws bottleneck direction and radius
             var bottleneckPlane = GenerateBottleneckPlane();


### PR DESCRIPTION
I reused the GetSlopeDirection function to figure out the direction vector the bottleneck plane was sloping towards.
Using this and the position of the bottleneck and the radius of the bottleneck I projected a position along the slope direction

You can see the yellow Debug.Line() always points to the lowest point on the bottleneck plane
https://gyazo.com/8c758804ec17321f9dd7fdcb904b3b65

The performance improvements are pretty good too, I tested by spawning 64 infinite liquid bottles angled so the function is called.
It reduces the GC allocation to 0B and the function self ms from ~2.8ms to < 0.1ms

https://i.imgur.com/C0LJNh1.png